### PR TITLE
feat: implement editing profiles

### DIFF
--- a/backend/api/profileAPI.js
+++ b/backend/api/profileAPI.js
@@ -24,57 +24,32 @@ router.post("/getUsername", function(req, res) {
 });
 
 // Get the bio for the user (Placeholder for now)
-router.post("/getBio", function(req, res) {
-
-    var bio;
+router.post("/getUserDetails", function(req, res) {
     const user = req.body.username;
-    console.log("Checking for user w/ username: " +user);
+    console.log("getting data for user w/ username: " +user);
     
-    User.find({username: user}, function (err){ 
-        res.send("Placeholder Bio");
-        });
+    User.find({username: user}) .then((data) => {
+        res.json(data);
+    })
 });
 
 
 // Update/Change the user's bio
 
-router.post("/changeBio",function(req,res){
-    const user = req.body.username;
-    var newBio;
-    console.log("Checking user validity for: "+username);
-
-    User.find({username: user}, function(err)
-    {
-       findOneAndUpdate(User.data.bio, newBio);
-        });
+router.post("/editProfile",function(req,res){
+    console.log("Updating "+req.body.username +"'s profile");
+    var profileChanges = {
+        name: req.body.name,
+        bio: req.body.bio,
+        website: req.body.website
+    };
+    User.findOneAndUpdate(
+        { username: req.body.username }, 
+        { $set: profileChanges },
+    ).then(post => {
+    });
     
 })
-
-// Get the user's name
-
-router.post("/getName", function(req,res)
-{
-    const user = req.body.name;
-    console.log("Checking for user w/ name: " +user);
-    
-    User.find({name: user}).then((data) => {
-        console.log(data)
-    res.send(data.name);
-    });
-});
-
-
-
-// Get the user's website link to their profile page
-
-router.post("/getWebLink", function(req,res){
-    const user = req.body.website;
-    console.log("Checking for website link..." + user);
-
-    User.find({name: user}); {
-        res.send(data.photo);
-    };
-});
 
 
 // Get user's profile picture for display

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,11 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { ReactSession } from 'react-client-session';
  
 import Feed from './pages/feed.js';
-import Profile from './pages/profile';
 import NewPost from './pages/newPost.js';
 import Register from './pages/register.js';
 import Login from './pages/login.js';
 import UserProfileWrapper from './components/getUsername';
+import EditProile from './pages/editProfile';
  
 ReactSession.setStoreType('localStorage');
 class App extends Component {
@@ -17,11 +17,11 @@ class App extends Component {
         <div>
             <Routes>
              <Route path="/" element={<Login />} exact/>
-             <Route path="/profile" element = {<Profile />}/>
              <Route path="/newpost" element = {<NewPost />}/>
              <Route path="/feed" element={<Feed />}/>
              <Route path="/signup" element={<Register />}/>
              <Route path="/user/:username" element={<UserProfileWrapper />}/>
+             <Route path="/editProfile" element={<EditProile />}/>
            </Routes>
 
         </div> 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -13,7 +13,7 @@ const Navigation = () => {
           &nbsp; &nbsp; &nbsp;
           <NavLink to="/newpost">New Post</NavLink>
           &nbsp; &nbsp; &nbsp;
-          <NavLink to="/profile">Profile</NavLink>
+          <NavLink to={"/user/" +ReactSession.get('username')} >My Profile</NavLink>
        </div>
     );
 }

--- a/src/pages/editProfile.js
+++ b/src/pages/editProfile.js
@@ -1,0 +1,121 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import { ReactSession } from 'react-client-session';
+import profilecss from './profile.css';
+import Logout from '../components/logout';
+import Navigation from '../components/Navigation';
+import { Navigate } from 'react-router-dom';
+
+
+class profile extends Component {
+    constructor(props) {
+        super(props);
+        this.state = 
+        {
+            username: ReactSession.get("username"),
+            bio: '',
+            name: '',
+            website: '',
+            redir: false
+        }
+        this.handleNameChange = this.handleNameChange.bind(this);
+        this.handleBioChange = this.handleBioChange.bind(this);
+        this.handleWebsiteChange = this.handleWebsiteChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+
+          handleNameChange(event) {
+           this.setState({name: event.target.value});
+          }
+          handleBioChange(event) {
+           this.setState({bio: event.target.value});
+         }
+         handleWebsiteChange(event) {
+             var weblink = event.target.value;
+           this.setState({website: weblink});
+         }
+
+         handleSubmit(event) {
+            axios.post('/api/profileAPI/editProfile',  {
+                username: this.state.username,
+                bio: this.state.bio,
+                name: this.state.name,
+                website: this.state.website,
+
+            }).then((response) => {
+            })
+                    .catch(() => {
+                            console.log('An error occoured');
+                    });
+                alert("Your changes have been saved");
+                this.setState({redir: true});
+
+         }
+    
+
+    componentDidMount() {
+
+        axios.post('/api/userAPI/checkUser',  {
+            username: this.state.username
+        }).then((response) => {
+            if(!response.data) {
+                alert("This user does not exist!");
+                this.setState({redir: true});
+            }
+        })
+                .catch(() => {
+                        console.log('An error occoured');
+                });
+
+        axios.post('/api/profileAPI/getUserDetails',  {
+            username: this.state.username
+        }).then((response) => {
+            console.log(response)
+            console.log(response.data[0].username);
+            this.setState({bio: response.data[0].bio,name: response.data[0].name, website: response.data[0].website});
+        })
+                .catch(() => {
+                        console.log('An error occoured');
+                });
+       }
+	
+	
+	//rendering
+	render() {
+        if(this.state.redir) 
+            return (<Navigate  to={"../user/"+this.state.username}  />);
+        else 
+            return (  
+                <div>
+                    <Navigation />;
+                    <div className='userRelatedPosts'>
+                        <label>
+                        name: &nbsp;
+                            <input type="text" className='inform' value={this.state.name} onChange={this.handleNameChange} />
+                        </label>
+                        <br />
+                        <label>
+                        bio: &nbsp;
+                            <textarea rows="10" cols="50" placeholder="Tell us about yourself..." className='inform' value={this.state.bio} onChange={this.handleBioChange} />
+                        </label>
+                        <br />
+                        <label>
+                        website: &nbsp;
+                            <input type="text" className='inform' value={this.state.website} onChange={this.handleWebsiteChange} />
+                        </label>
+                        <br />
+                        <input type="submit" value="Save Changes" onClick={this.handleSubmit} />
+                    </div>
+                    <div className='profile'>
+                        <h2 className ='editPreview'>Preview</h2>
+                        <h2>{this.state.username}</h2>
+                        <h3>{this.state.name}</h3>
+                        <p>{this.state.bio}</p>
+                        {this.state.website !=undefined? (<p><a href={this.state.website} target="_blank">Website</a></p>) : null}
+                    </div> 
+                </div>
+		);
+	}
+}
+export default profile;

--- a/src/pages/profile.css
+++ b/src/pages/profile.css
@@ -34,3 +34,7 @@
     border-bottom-right-radius: 5px;
 }
 
+.editPreview {
+    text-align: center;
+}
+

--- a/src/pages/userProfile.js
+++ b/src/pages/userProfile.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 import { ReactSession } from 'react-client-session';
-//import profilecss from './profile.css';
+import profilecss from './profile.css';
 import Logout from '../components/logout';
 import Navigation from '../components/Navigation';
-import { Navigate } from 'react-router-dom';
+import { Navigate, NavLink } from 'react-router-dom';
 
 
 class profile extends Component {
@@ -13,6 +13,8 @@ class profile extends Component {
         {
             username: this.props.username,
             bio: '',
+            name: '',
+            website: '',
             posts: [],
             likes: [],
             redir: false
@@ -33,11 +35,12 @@ class profile extends Component {
                         console.log('An error occoured');
                 });
 
-        axios.post('/api/profileAPI/getBio',  {
+        axios.post('/api/profileAPI/getUserDetails',  {
             username: this.state.username
         }).then((response) => {
-            const data = response.data;
-            this.setState({bio: data});
+            console.log(response)
+            console.log(response.data[0].website);
+            this.setState({bio: response.data[0].bio,name: response.data[0].name, website: response.data[0].website});
         })
                 .catch(() => {
                         console.log('An error occoured');
@@ -62,12 +65,13 @@ class profile extends Component {
                     </div>
                     <div className='profile'>
                         <h2>{this.state.username}</h2>
+                        <h3>{this.state.name}</h3>
                         <p>{this.state.bio}</p>
-                        {(ReactSession.get("username") == this.state.username)? (<div><p>Edit Profile here</p> <Logout /> </div>): null}
+                        {this.state.website !=undefined? (<p><a href={this.state.website}>Website</a></p>) : null}
+                        {(ReactSession.get("username") == this.state.username)? (<div><NavLink to="../../editProfile"><input type="submit" value="Edit Profile" /></NavLink> <Logout /> </div>): null}
                     </div> 
                 </div>
 		);
 	}
 }
-
 export default profile;


### PR DESCRIPTION
Post request made in lieu of Kanza who is having issues
Users may now edit their name, bio, and website. On the edit profile page, users are shown a preview of their edits as they type. If a user hasn't set an element, it won't appear.
Also merged the profile pages together, added the edit profile page to the routes, and modified the backend to work with this frontend
Fully resolves #20