### PR TITLE
refactor: Extract posts and profile block

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Register from './pages/register.js';
 import Login from './pages/login.js';
 import UserProfileWrapper from './components/getUsername';
 import EditProile from './pages/editProfile';
+import Search from './pages/search';
  
 ReactSession.setStoreType('localStorage');
 class App extends Component {
@@ -19,6 +20,7 @@ class App extends Component {
              <Route path="/" element={<Login />} exact/>
              <Route path="/newpost" element = {<NewPost />}/>
              <Route path="/feed" element={<Feed />}/>
+             <Route path="/search" element={<Search />}/>
              <Route path="/signup" element={<Register />}/>
              <Route path="/user/:username" element={<UserProfileWrapper />}/>
              <Route path="/editProfile" element={<EditProile />}/>

--- a/src/components/post.js
+++ b/src/components/post.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import { NavLink } from 'react-router-dom';
+import pagecss from '../pages/page.css'
+import Comments from './Comments';
+import Likes from './Likes';
+import { Carousel } from 'react-responsive-carousel';
+import '../../node_modules/react-responsive-carousel/lib/styles/carousel.min.css';
+class post extends Component {
+	constructor(props) {
+        super();
+        this.state = {
+          post: props.post
+        };
+      }
+
+    carouselImages = (attachments) => {
+        return attachments.map((attachment) => {
+            return (<div> 
+                <img src={attachment} alt="Image Placeholder" width="auto" height="auto"/>
+            </div>);
+        })
+    }
+
+    displayImages = (attachments) => {
+        if (attachments.length > 1) {
+            return (<Carousel showArrows={true} width={500} height={300}>
+                { this.carouselImages(attachments) } 
+            </Carousel>);
+        } else if (attachments.length == 1) {
+            return (<img src={attachments[0]} alt="Image Placeholder" width="500" height="300"/>);
+        }
+        return;
+    }
+
+    //maps each post
+    displayPost = (post) => {
+        return (
+            <div className = "post" style={{margin: "auto"}}>
+                <h4> <NavLink to={'/user/' + post.postedBy}>{post.postedBy}</NavLink></h4> 
+                <p><small>{post.time}</small></p>
+                <p>{post.content}</p>
+                {this.displayImages(post.attachments)}
+                <Likes postID={""+post._id} />
+                <Comments postID={""+post._id} />
+            </div>
+        );
+    }
+
+    render() {
+        return this.displayPost(this.state.post);
+    }
+}
+export default post;

--- a/src/components/profileBlock.js
+++ b/src/components/profileBlock.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import { ReactSession } from 'react-client-session';
+import pagecss from '../pages/page.css';
+import Logout from './logout';
+import { NavLink } from 'react-router-dom';
+
+class profileBLock extends Component {
+	constructor(props) {
+        super();
+        this.state = {
+          user: props.user
+        };
+      }
+
+    render() {
+        return (
+        <div className='profile'>
+            <h2>{this.state.user.username}</h2>
+            <h3>{this.state.user.name}</h3>
+            <p>{this.state.user.bio}</p>
+            {this.state.user.website !=undefined || this.state.user.website !=""? (<p><a href={this.state.user.website}>Website</a></p>) : null}
+            {(ReactSession.get("username") == this.state.user.username)? (<div><NavLink to="../../editProfile"><input type="submit" value="Edit Profile" /></NavLink> <Logout /> </div>): null}
+        </div> 
+         );
+    }
+}
+export default profileBLock;

--- a/src/pages/feed.js
+++ b/src/pages/feed.js
@@ -8,6 +8,7 @@ import MustLogin from '../components/mustLogin';
 import Comments from '../components/Comments';
 import Likes from '../components/Likes';
 import PlaceholderPost from '../components/placeholderPost/placeholderPost';
+import Post from '../components/post';
 import '../components/placeholderPost/placeholderpost.css';
 import { Carousel } from 'react-responsive-carousel';
 import '../../node_modules/react-responsive-carousel/lib/styles/carousel.min.css';
@@ -16,9 +17,7 @@ class feed extends Component {
 	
 	state = 
 	{
-		title: '',
-		body: '',
-		posts: []
+		posts:[]
 	}
 
 	//retrieves posts whenever component mounts
@@ -37,39 +36,13 @@ class feed extends Component {
 		  	console.log('Error retrieving data!');
 		});
 	}
-
-	carouselImages = (attachments) => {
-		return attachments.map((attachment) => {
-			return (<div> 
-				<img src={attachment} alt="Image Placeholder" width="auto" height="auto"/>
-			</div>);
-		})
-	}
-
-	displayImages = (attachments) => {
-		if (attachments.length > 1) {
-			return (<Carousel showArrows={true} width={500} height={300}>
-				{ this.carouselImages(attachments) } 
-			</Carousel>);
-		} else if (attachments.length == 1) {
-			return (<img src={attachments[0]} alt="Image Placeholder" width="500" height="300"/>);
-		}
-		return;
-	}
 	
 	//maps each post
 	displayPosts = (posts) => {
 		//if there are no posts
 		if (!posts.length) return null;
 		return posts.map((post, index) => (
-			<div className = "post" style={{margin: "auto"}} key = {index}>
-				<h4> <NavLink to={'/user/' + post.postedBy}>{post.postedBy}</NavLink></h4> 
-				<p><small>{post.time}</small></p>
-				<p>{post.content}</p>
-				{this.displayImages(post.attachments)}
-				<Likes postID={""+post._id} />
-				<Comments postID={""+post._id} />
-			</div>
+			<Post post={post}/>
 		));
 	}
 	

--- a/src/pages/page.css
+++ b/src/pages/page.css
@@ -1,6 +1,7 @@
 .post {
     display: block;
 	width: 70%;
+    margin-top: 10px;
 	margin: auto;
 	border: 2px ridge #999;
 	padding: 10px;
@@ -79,3 +80,19 @@
     padding: 10px;
 }
 
+.searchbox {
+
+    border: none;
+    border-bottom: 2px solid slateblue;
+    width: 50%;
+    margin-right: 5%;
+}
+.searchbox:focus {
+    border: none;
+    border-bottom: 2px solid blue;
+    outline: none;
+}
+
+.searchOrder {
+    width: 200px;
+}

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import Navigation from '../components/Navigation';
+import { NavLink } from 'react-router-dom';
+import pagecss from './page.css'
+
+import MustLogin from '../components/mustLogin';
+import Comments from '../components/Comments';
+import Likes from '../components/Likes';
+import PlaceholderPost from '../components/placeholderPost/placeholderPost';
+import '../components/placeholderPost/placeholderpost.css';
+import { Carousel } from 'react-responsive-carousel';
+import '../../node_modules/react-responsive-carousel/lib/styles/carousel.min.css';
+
+class search extends Component {
+	
+	state = 
+	{
+        query: '',
+        searchPost: true,
+        searchRecent: true,
+        order: true,
+        ready: false,
+		posts: []
+	}
+
+
+
+    handleQueryChange(event) {
+        this.setState({query: event.target.value});
+    }
+
+    handleTypeChange(event) {
+        this.setState({searchPost: event.target.value});
+    }
+    handleOrderChange(event) {
+        this.setState({order: event.target.value});
+    }
+
+	//retrieves posts whenever component mounts
+	componentDidMount = () => {
+		this.getPosts();
+	}
+
+	//retrieves our posts
+	getPosts = () => {
+		axios.post('/api/contentfeedAPI/getAllPosts', {}) //api route goes here
+		.then((response) => {
+			const data = response.data;
+		  	this.setState({ posts: data });
+		})
+		.catch(() => {
+		  	console.log('Error retrieving data!');
+		});
+	}
+
+	
+
+    dispPostOptions() {
+        if(this.state.searchPost)
+            return (
+                    <select className="searchOrder">
+                        <option value="0">Most Recent</option>
+                        <option value="1">Most Popular</option>
+                    </select>
+
+            );
+        else return null;
+    }
+	
+	//rendering
+	render() {
+		return (  
+			<div>
+				<MustLogin />
+				<Navigation />
+                <div className="post">
+                    <input type="text" className='searchbox' value={this.state.user} placeholder="Search..." onChange={this.handleQueryChange.bind(this)}/>
+                    <input type="radio" name="type" id="post" value="true" checked={true} onChange={this.handleTypeChange.bind(this)}/>
+                    <label for="post">Posts</label>
+                    <input type="radio" name="type" id="user" value="false" onChange={this.handleTypeChange.bind(this)}/>
+                    <label for="user">Users</label>
+                    <br/>
+                    {this.state.searchPost? this.dispPostOptions() :null }
+                    <input type="radio" name="order" id="asc" value="true" onChange={this.handleOrderChange.bind(this)}/>
+                    <label for="asc">Ascending</label>
+                    <input type="radio" name="order" id="dec" value="false" checked={true} onChange={this.handleOrderChange.bind(this)}/>
+                    <label for="dec">Decending</label>
+                </div>
+				{this.state.ready? this.displayPosts(this.state.posts) : null}
+                {this.state.ready? <PlaceholderPost /> : null}
+			</div> 
+		);
+	}
+}
+
+export default search;

--- a/src/pages/userProfile.js
+++ b/src/pages/userProfile.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import axios from 'axios';
 import { ReactSession } from 'react-client-session';
 import pagecss from './page.css';
-import Logout from '../components/logout';
+import ProfileBlock from '../components/profileBlock';
 import Navigation from '../components/Navigation';
 import { Navigate, NavLink } from 'react-router-dom';
 
@@ -12,9 +12,7 @@ class profile extends Component {
         state = 
         {
             username: this.props.username,
-            bio: '',
-            name: '',
-            website: '',
+            user: null,
             posts: [],
             likes: [],
             redir: false
@@ -38,9 +36,7 @@ class profile extends Component {
         axios.post('/api/profileAPI/getUserDetails',  {
             username: this.state.username
         }).then((response) => {
-            console.log(response)
-            console.log(response.data[0].website);
-            this.setState({bio: response.data[0].bio,name: response.data[0].name, website: response.data[0].website});
+            this.setState({user: response.data[0]});
         })
                 .catch(() => {
                         console.log('An error occoured');
@@ -63,13 +59,8 @@ class profile extends Component {
                     <div className='userRelatedPosts'>
                         <h2>Posts go here</h2>
                     </div>
-                    <div className='profile'>
-                        <h2>{this.state.username}</h2>
-                        <h3>{this.state.name}</h3>
-                        <p>{this.state.bio}</p>
-                        {this.state.website !=undefined || this.state.website !=""? (<p><a href={this.state.website}>Website</a></p>) : null}
-                        {(ReactSession.get("username") == this.state.username)? (<div><NavLink to="../../editProfile"><input type="submit" value="Edit Profile" /></NavLink> <Logout /> </div>): null}
-                    </div> 
+                    {this.state.user!=null ?<ProfileBlock user={this.state.user}/> : null}
+                    
                 </div>
 		);
 	}


### PR DESCRIPTION
Extracted posts from feed and profile blocks from userProfile into their own components. Previously, both were embedded into the larger pages, but this was bad design and severley limits code reuse.
Both can be found in src/components and can be included by passing a non-null post or user from the backend as a props argument "post" or "user" respectively
Also includes some preliminary code and styling for the search page.
Not pertinent to any issue in particular, but is a very necessary change