### PR TITLE
feat: Implement searching

### DIFF
--- a/backend/api/searchAPI.js
+++ b/backend/api/searchAPI.js
@@ -1,0 +1,44 @@
+const express = require("express");
+const app = express();
+
+var router = express.Router();
+var bodyParser = require('body-parser');
+const Post = require('../models/post');
+const User = require('../models/user');
+
+router.use(bodyParser.urlencoded({ extended: true }));
+
+router.post("/search", function(req, res) {	
+    const query = req.body.exact? req.body.query : { "$regex": req.body.query, "$options": "i" };
+    const type = req.body.type;
+    const sort = req.body.sort;
+    const order = req.body.order==="ascending"? 1 : -1;
+    
+    switch (type) {
+        case "posts":
+
+            switch (sort) {
+                case "recent":
+                    Post.find({$or:[{postedBy: query },{content: query }, {tags: query}]}).sort({"$natural":order}).limit(25).then((data) => {
+                        res.json(data);
+                    });
+                break;
+            
+                case "popular":
+                    Post.find({$or:[{postedBy: query },{content: query } , {tags: query}]}).sort({likeCt:order}).limit(25).then((data) => {
+                        res.json(data);
+                    });
+                break;
+            }
+        break;
+        case "users":
+            User.find({$or:[{username: query },{name: query }]}).sort({"$natural":-1}).limit(25).then((data) => {
+                res.json(data);
+            });
+
+        break;
+    }
+
+});
+
+module.exports = router;

--- a/backend/models/post.js
+++ b/backend/models/post.js
@@ -10,7 +10,7 @@ const postSchema = new Schema({
 	attachments: [{type: String}],
   comments: [{commenter: String, comment: String}],
   likeCt: {type: Number},
-
+  tags: [{type: String}],
   likers: [{type: String}],
 
 	time:{ type: Date, default: Date.now },

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,9 @@ app.use('/api/profileAPI', profileAPI);
 
 const loginAPI = require('./api/loginAPI');
 app.use('/api/loginAPI', loginAPI);
+
+const searchAPI = require('./api/searchAPI');
+app.use('/api/searchAPI', searchAPI);
 //-----
 //app.use(express.static(path.join(__dirname, '../build/')))
 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -15,6 +15,8 @@ const Navigation = () => {
           &nbsp; &nbsp; &nbsp;
           <NavLink to="/newpost">New Post</NavLink>
           &nbsp; &nbsp; &nbsp;
+          <NavLink to="/search">Search</NavLink>
+          &nbsp; &nbsp; &nbsp;
           <NavLink to={"/user/" +ReactSession.get('username')} >My Profile</NavLink>
        </div>
     );

--- a/src/components/profileBlock.js
+++ b/src/components/profileBlock.js
@@ -8,13 +8,14 @@ class profileBLock extends Component {
 	constructor(props) {
         super();
         this.state = {
-          user: props.user
+          user: props.user,
+          align: props.align
         };
       }
 
     render() {
         return (
-        <div className='profile'>
+        <div className='profile' style={ this.state.align === "center"? {margin: "auto"} : {float: this.state.align}}>
             <h2>{this.state.user.username}</h2>
             <h3>{this.state.user.name}</h3>
             <p>{this.state.user.bio}</p>

--- a/src/pages/page.css
+++ b/src/pages/page.css
@@ -3,6 +3,7 @@
 	width: 70%;
     margin-top: 10px;
 	margin: auto;
+    margin-bottom: 20px;
 	border: 2px ridge #999;
 	padding: 10px;
 	text-align:left;
@@ -45,9 +46,8 @@
     text-align: center;
 }
 .profile {
-    display: block;
+    display: table;
 	width: 30%;
-    float: right;
 	margin: 10px;
 	border: 2px ridge #999;
 	padding: 10px;

--- a/src/pages/userProfile.js
+++ b/src/pages/userProfile.js
@@ -59,7 +59,7 @@ class profile extends Component {
                     <div className='userRelatedPosts'>
                         <h2>Posts go here</h2>
                     </div>
-                    {this.state.user!=null ?<ProfileBlock user={this.state.user}/> : null}
+                    {this.state.user!=null ?<ProfileBlock user={this.state.user} align={"right"}/> : null}
                     
                 </div>
 		);


### PR DESCRIPTION
Searching has been implemented. Users and posts can be sorted based on a simple text query. Posts must match the query in their postedBy (author) content, or tags. Users must match the query in their username or name.
Additionally, there is an option to return results that exactly match the search query, or include the query.
Finally, posts can be sorted by recency or popularity (most likes) in asending or decending order. Users can not be sorted.
Fully resolves #38
----Other changes----
Post schema was updated to add tags to facilitate in testing. One post in the database was also tagged
Search page was added to the navbar
The profile block and user profile page were updated to add an aditional parameter, align, to specify where to float the block; left, center, or right, This was necessary so when searching users, they would display properly.
