### PR TITLE
feat: Implement explore page

### DIFF
--- a/backend/api/searchAPI.js
+++ b/backend/api/searchAPI.js
@@ -9,9 +9,18 @@ router.use(bodyParser.urlencoded({ extended: true }));
 
 router.post("/getPostsWithTag", function(req, res) {    
     const tag = req.body.tag;
-    Post.find({tags: {$in: tag}}).sort({"$natural":-1}).then((data) => {
-        res.json(data);
-    });
+    const recent = req.body.sort === 'recent'? true : false;
+
+    if(recent) {
+        Post.find({tags: {$in: tag}}).sort({"$natural":-1}).then((data) => {
+            res.json(data);
+        });
+    }
+    else {
+        Post.find({tags: {$in: tag}}).sort({likeCt:-1}).then((data) => {
+            res.json(data);
+        });
+    }
  });
 
 

--- a/backend/api/searchAPI.js
+++ b/backend/api/searchAPI.js
@@ -3,21 +3,16 @@ const app = express();
 
 var router = express.Router();
 var bodyParser = require('body-parser');
-const post = require('../models/post');
+const Post = require('../models/post');
 const User = require('../models/user');
-
-//API for tags
-axios.post('/api/searchAPI/getPostsWithTag', {
-    tag: this.state.tag
-     }).then((response) => {
-     const data = response.data;
-         this.setState({results: data});
- })
- .catch(() => {
-         console.log('Error retrieving data!');
- });
-
 router.use(bodyParser.urlencoded({ extended: true }));
+
+router.post("/getPostsWithTag", function(req, res) {    
+    const tag = req.body.tag;
+    Post.find({tags: {$in: tag}}).sort({"$natural":-1}).then((data) => {
+        res.json(data);
+    });
+ });
 
 router.post("/search", function(req, res) {	
     const query = req.body.exact? req.body.query : { "$regex": req.body.query, "$options": "i" };

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Login from './pages/login.js';
 import UserProfileWrapper from './components/getUsername';
 import EditProile from './pages/editProfile';
 import Search from './pages/search';
+import Explore from './pages/explore';
  
 ReactSession.setStoreType('localStorage');
 class App extends Component {
@@ -24,6 +25,7 @@ class App extends Component {
              <Route path="/signup" element={<Register />}/>
              <Route path="/user/:username" element={<UserProfileWrapper />}/>
              <Route path="/editProfile" element={<EditProile />}/>
+             <Route path="/explore" element={<Explore />}/>
            </Routes>
 
         </div> 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -17,6 +17,8 @@ const Navigation = () => {
           &nbsp; &nbsp; &nbsp;
           <NavLink to="/search">Search</NavLink>
           &nbsp; &nbsp; &nbsp;
+          <NavLink to="/explore">Explore</NavLink>
+          &nbsp; &nbsp; &nbsp;
           <NavLink to={"/user/" +ReactSession.get('username')} >My Profile</NavLink>
        </div>
     );

--- a/src/pages/explore.js
+++ b/src/pages/explore.js
@@ -1,0 +1,87 @@
+
+import React from 'react';
+import Navbar from '../components/Navigation';
+import TagAdder from '../components/TagAdder';
+//import { ReactSession } from 'react-client-session';
+import axios from 'axios';
+import pagecss from './page.css'
+
+import { FOCUSABLE_SELECTOR } from '@testing-library/user-event/dist/utils';
+ 
+//The idea is to give the react component control over the form
+class explore extends React.Component {
+   constructor(props) {
+     super(props);
+     this.state = {results: [], gotResults: false};
+     this.displayResults = this.displayResults.bind(this);
+     this.handleSubmit = this.handleSubmit.bind(this);
+   }
+
+ 
+   handleSubmit(event) {
+    var tags = [];
+    var tagList = document.querySelector(".tag-list");
+    for (var i = 0; i < tagList.options.length; i++) {
+      if (tagList.options[i].selected) {
+        tags.push(tagList.options[i].value);
+      }
+    }
+    if(tags.length ===0 ) {
+        alert("Please enter a tag to search for");
+        return;
+    } 
+
+    this.setState({results: [], gotResults: false});
+    axios.post('/api/searchAPI/getPostsWithTag', {
+        tag: tags
+         }).then((response) => {
+         const data = response.data;
+            for(var i=0;i< data.length; i++) {
+                if(data[i].attachments.length > 0) {
+                    this.setState({results: [...this.state.results, ...data[i].attachments]});
+                }
+            }
+            this.setState({gotResults: true});
+            console.log(this.state.results);
+     })
+     .catch((err) => {
+             console.log(err);
+     });
+   }
+ 
+   displayResults() {
+    if (!this.state.results.length && this.state.gotResults) {
+        return(<h2 style={{textAlign: "center"}}>There weren't any images with those tags </h2>)
+    }
+    else {
+        return  this.state.results.map((img, index) => (
+            <>
+                <img src={img} className="exploreImage"/>&nbsp;
+            </>
+        ));
+
+
+    }
+
+   }
+
+   render() {
+
+      return (
+        <div>
+          <Navbar />
+          <div className='post'>
+            <TagAdder />
+            <input type="submit" value="Search" onClick={this.handleSubmit}/>
+          </div>
+          <br/>
+            <div className='exploreImageWrapper'>
+                {this.displayResults()}
+            </div>
+          </div>
+      );
+     }
+
+}
+export default explore;
+

--- a/src/pages/explore.js
+++ b/src/pages/explore.js
@@ -12,10 +12,14 @@ import { FOCUSABLE_SELECTOR } from '@testing-library/user-event/dist/utils';
 class explore extends React.Component {
    constructor(props) {
      super(props);
-     this.state = {results: [], gotResults: false};
+     this.state = {results: [], gotResults: false, selectedSort:'recent' };
      this.displayResults = this.displayResults.bind(this);
      this.handleSubmit = this.handleSubmit.bind(this);
+     this.handleSortChange = this.handleSortChange.bind(this);
    }
+   handleSortChange(event) {
+    this.setState({selectedSort: event.target.value});
+}
 
  
    handleSubmit(event) {
@@ -33,7 +37,8 @@ class explore extends React.Component {
 
     this.setState({results: [], gotResults: false});
     axios.post('/api/searchAPI/getPostsWithTag', {
-        tag: tags
+        tag: tags,
+        sort: this.state.selectedSort
          }).then((response) => {
          const data = response.data;
             for(var i=0;i< data.length; i++) {
@@ -72,7 +77,11 @@ class explore extends React.Component {
           <Navbar />
           <div className='post'>
             <TagAdder />
-            <input type="submit" value="Search" onClick={this.handleSubmit}/>
+            <select className="searchOrder" onChange={this.handleSortChange}>
+                        <option value="recent" selected={this.state.selectedSort === "recent"}>Most Recent</option>
+                        <option value="popular" selected={this.state.selectedSort === "popular"}>Most Popular</option>
+            </select>
+            &nbsp;&nbsp;<input type="submit" value="Search" onClick={this.handleSubmit}/>
           </div>
           <br/>
             <div className='exploreImageWrapper'>

--- a/src/pages/page.css
+++ b/src/pages/page.css
@@ -12,6 +12,24 @@
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
+.exploreImageWrapper {
+    display:block;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+}
+
+.exploreImage {
+    margin-left: auto;
+    margin-right: auto;
+    width: 30%;
+    height: 300px;
+    border: 2px ridge #999;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+}
 
 .inform {
     padding: 3px;


### PR DESCRIPTION
Pair programed with Fatema. The explore page is now live. Users can enter a tag or set of tags and be shown all images from all posts with that tag. If no images can be shown, a message will be displayed
Also added styling, added the page to routing as /explore, added the page to the navbar, and finalized backend API
resolves #40