### PR TITLE
feat: Implement account deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-scripts": "5.0.0",
         "reacts": "^0.0.0",
         "rsuite": "^5.7.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "yesno-dialog": "^0.2.1"
       },
       "engines": {
         "node": "17.4.0"
@@ -17395,6 +17396,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/yesno-dialog": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/yesno-dialog/-/yesno-dialog-0.2.1.tgz",
+      "integrity": "sha512-Yhlyy1vXDpW3d4XCI3QUOw0om4+DfpJMIQBnHKN6uAkysH0l5nrJevS+7NioGL52lGXQG1T1VaAeWgmlOijW1w=="
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -30002,6 +30008,11 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "yesno-dialog": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/yesno-dialog/-/yesno-dialog-0.2.1.tgz",
+      "integrity": "sha512-Yhlyy1vXDpW3d4XCI3QUOw0om4+DfpJMIQBnHKN6uAkysH0l5nrJevS+7NioGL52lGXQG1T1VaAeWgmlOijW1w=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-scripts": "5.0.0",
     "reacts": "^0.0.0",
     "rsuite": "^5.7.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "yesno-dialog": "^0.2.1"
   },
   "scripts": {
     "start": "node backend/server.js ",

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import UserProfileWrapper from './components/getUsername';
 import EditProile from './pages/editProfile';
 import Search from './pages/search';
 import Explore from './pages/explore';
+import AccountSettings from './pages/accountSettings'
  
 ReactSession.setStoreType('localStorage');
 class App extends Component {
@@ -26,6 +27,7 @@ class App extends Component {
              <Route path="/user/:username" element={<UserProfileWrapper />}/>
              <Route path="/editProfile" element={<EditProile />}/>
              <Route path="/explore" element={<Explore />}/>
+             <Route path="/settings" element={<AccountSettings />}/>
            </Routes>
 
         </div> 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -26,6 +26,7 @@ const Navigation = () => {
             You are logged in as: {ReactSession.get('username')}
             &nbsp; &nbsp;
             <Logout />
+            <NavLink to="/settings" style={{float: 'right'}}>Account Settings</NavLink>
          </div>
          <br />
         </>

--- a/src/components/deleteUser.js
+++ b/src/components/deleteUser.js
@@ -1,0 +1,99 @@
+import React, { Component, useImperativeHandle } from 'react';
+import axios from 'axios';
+import sha from 'js-sha512';
+import pagecss from '../pages/page.css'
+import { ReactSession } from 'react-client-session';
+import unliked from '../img/unliked.png';
+import liked from '../img/liked.png';
+import yesno from "yesno-dialog";
+import { Navigate } from "react-router-dom";
+class HeartButton extends React.Component {
+  constructor(props) {
+    super();
+    this.state = {
+      redir: false,
+      pass: ""
+    };
+    this.handlePassChange = this.handlePassChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handlePassChange(event) {
+    this.setState({pass: event.target.value});
+  }
+
+
+  componentDidMount = () => {
+    
+  }
+
+
+  
+
+
+
+ 
+
+   async handleSubmit(event) {
+    if(this.state.pass == '') {
+      alert("Missing username or password! Please try again.")
+      return;
+    }
+   const hashedPassword = sha.sha512(this.state.pass);
+
+    await axios.post('/api/loginAPI/checkUser',  {
+     username: ReactSession.get("username"),
+     password: hashedPassword
+    }).then((response) => {
+             const data = response.data;
+             if(!data) {
+               alert("Incorrect Password")
+               return;
+             }
+             else {
+                  if (window.confirm("Warning: This will permanently delete your Cutest Paw account, including your posts, likes, and comments. Are you sure you would like to continue?") === true) {
+                  
+                    axios.post('/api/userAPI/deleteUser', {
+                      username: ReactSession.get("username")
+                    })
+                    .then((response) => {
+                      alert("Your account has been successfully deleted");
+                      ReactSession.set("username", "");
+                      this.setState({redir: true});
+                    })
+                    .catch(() => {
+                          console.log('Error retrieving data!');
+                    });  
+                  }
+            }
+
+    }).catch(() => {
+               console.log('An error occoured');
+         }
+    );
+  }
+
+  render() {
+    const likes = this.state.likes;
+    if (this.state.redir) {
+        return (
+            <Navigate to="../" />
+        );
+    }
+    else {
+        return (
+            <>
+              <h3>Delete my Account</h3>
+              <p>Permanently delete your account, including your posts, likes, comments, and all other information</p>
+              <p>WARNING: This action can not be undone!</p>
+                Confirm your password: <input type="password"  className='inform' value={this.state.pass} onChange={this.handlePassChange} />
+                <input type="submit" value="Delete Account" id='deleteButton' onClick={this.handleSubmit} />
+            </>
+        );
+    }
+  }
+}
+
+
+
+export default HeartButton;

--- a/src/pages/accountSettings.js
+++ b/src/pages/accountSettings.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import Navigation from '../components/Navigation';
+import DeleteUser from '../components/deleteUser';
+import { NavLink } from 'react-router-dom';
+import { ReactSession } from 'react-client-session';
+import pagecss from './page.css'
+
+import MustLogin from '../components/mustLogin';
+import '../../node_modules/react-responsive-carousel/lib/styles/carousel.min.css';
+
+class accountSettings extends Component {
+	
+	state = 
+	{
+	}
+
+	render() {
+		return (  
+			<div>
+				<MustLogin />
+				<Navigation />
+				<DeleteUser />
+				
+			</div> 
+		);
+	}
+}
+
+export default accountSettings;


### PR DESCRIPTION
Users are now able to delete their accounts. On providing a correct password and confirming the following dialog, all of the user's presence on cutest paw will be removed, including posts, likes, comments, notifications, their name on following and follower lists, and finally the account itself.
An account settings page was added to hold the delete user component and the other 3 account settings components. It was also added to the navbar and routing.
The User API contains the deleteUser route. Finally, Packages were update to include yesnodialog, which may be a useful library, although I decided against using it.
Fully resolves #66