### PR TITLE
feat: Implemented notifications

### DIFF
--- a/backend/api/notificationAPI.js
+++ b/backend/api/notificationAPI.js
@@ -1,0 +1,31 @@
+var express = require("express");
+const app = express();
+
+var router = express.Router();
+var bodyParser = require("body-parser");
+
+const User = require('../models/user');
+const Notif = require("../models/notification");
+
+router.use(bodyParser.urlencoded({ extended: true }));
+
+
+router.post("/getNotifs", function (req, res) {
+  const user = req.body.username;
+
+  Notif.find({ toUser: user }).sort({"$natural":-1}).limit(25).then((notifs) => {
+    res.send(notifs);
+  });
+});
+
+router.post("/getUpdateNotifCheckedTime", function (req, res) {
+    const user = req.body.username;
+    let date = new Date();
+
+    User.findOneAndUpdate({username: user}, {notifCheckedTime: date.toISOString()}).then((user) => {
+        res.send(user.notifCheckedTime);
+      });
+
+  });
+
+module.exports = router;

--- a/backend/api/postAPI.js
+++ b/backend/api/postAPI.js
@@ -7,6 +7,7 @@ var bodyParser = require('body-parser');
 
 
 const Post = require('../models/post');
+const Notif = require('../models/notification');
 
 router.use(bodyParser.urlencoded({ extended: true }));
 
@@ -59,10 +60,27 @@ router.post("/writeNewComment", function(req,res){
         commenter: req.body.commenter,
         comment: req.body.comment
     };
+    var postAuthor = "";
     Post.findOneAndUpdate(
         { _id: req.body.postID }, 
         { $push: { comments: comment } },
     ).then(post => {
+
+        var fromUser = req.body.commenter + "";
+        var toUser = post.postedBy + "";
+        var notifType = "comment";
+        var context = req.body.postID;
+        if(fromUser !== toUser) {
+            var notifData = {fromUser: fromUser, toUser: toUser, notifType: notifType, context: context};
+            const notif = new Notif(notifData);
+            notif.save()
+        }
+
+
+
+    })
+    .catch((err) => {
+        console.log(err);
     });
 
 });
@@ -97,19 +115,21 @@ router.post('/like', async(req, res) =>{
     });
 
 
-    Post.findOneAndUpdate(
-        { _id: req.body.postID }, 
-        { $push: {likers: req.body.username}}
-    ).then(post => {
-    });
 
     Post.findOneAndUpdate(
         { _id: req.body.postID }, 
-        { $inc: {likeCt: 1}  }
+        { $push: {likers: req.body.username}, $inc: {likeCt: 1}  }
     ).then(post => {
+        var fromUser = req.body.username + "";
+        var toUser = post.postedBy + "";
+        var notifType = "like";
+        var context = req.body.postID;
+        if(fromUser !== toUser) {
+            var notifData = {fromUser: fromUser, toUser: toUser, notifType: notifType, context: context};
+            const notif = new Notif(notifData);
+            notif.save()
+        }
     });
-
-
 });
 
 module.exports = router;

--- a/backend/api/profileAPI.js
+++ b/backend/api/profileAPI.js
@@ -8,6 +8,7 @@ var bodyParser = require('body-parser');
 
 
 const User = require('../models/user');
+const Notif = require('../models/notification');
 
 router.use(bodyParser.urlencoded({ extended: true }));
 
@@ -93,7 +94,32 @@ router.post("/follow", function(req, res) {
             User.findOneAndUpdate(
                 { username: thisUser }, 
                 { $push: {following: userToFollow}}
-            ).then(result => {});
+            ).then(result => {     
+
+              var fromUser = req.body.thisUser + "";
+              var toUser = req.body.username + "";
+              var notifType = "follow";
+              var context = "";
+              if(fromUser !== toUser) {
+                 var notifData = {fromUser: fromUser, toUser: toUser, notifType: notifType, context: context};
+                 const notif = new Notif(notifData);
+                 notif.save()
+              }
+            });
+
+
+            //new notif on comment
+            var fromUser = req.body.thisUser + "";
+            var toUser = req.body.userToFollow + "";
+            var notifType = "follow";
+            var context = "";
+            var notifData = {fromUser: fromUser, toUser: toUser, notifType: notifType, context: context};
+            const notif = new Notif(notifData);
+            notif.save()
+            .catch((err) => {
+                console.log(err);
+            });
+
         }
 
     });

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -36,6 +36,7 @@ const userSchema = new Schema(
     following: [{type: String}],
     followers: [{type: String}],
     likesVisible: {type: Boolean, default: true},
+    notifCheckedTime: {type: Date, default: Date.now},
   },
   { id: true }
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,8 @@ app.use('/api/loginAPI', loginAPI);
 
 const searchAPI = require('./api/searchAPI');
 app.use('/api/searchAPI', searchAPI);
+const notificationAPI = require('./api/notificationAPI');
+app.use('/api/notificationAPI', notificationAPI);
 //-----
 //app.use(express.static(path.join(__dirname, '../build/')))
 

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import UserProfileWrapper from './components/getUsername';
 import EditProile from './pages/editProfile';
 import Search from './pages/search';
 import Explore from './pages/explore';
+import Notifications from './pages/notifications';
 import AccountSettings from './pages/accountSettings'
  
 ReactSession.setStoreType('localStorage');
@@ -27,6 +28,7 @@ class App extends Component {
              <Route path="/user/:username" element={<UserProfileWrapper />}/>
              <Route path="/editProfile" element={<EditProile />}/>
              <Route path="/explore" element={<Explore />}/>
+             <Route path="/notifications" element={<Notifications />}/>
              <Route path="/settings" element={<AccountSettings />}/>
            </Routes>
 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -21,6 +21,8 @@ const Navigation = () => {
           &nbsp; &nbsp; &nbsp;
           <NavLink to="/explore">Explore</NavLink>
           &nbsp; &nbsp; &nbsp;
+          <NavLink to="/notifications">Notifications</NavLink>
+          &nbsp; &nbsp; &nbsp;
             <NavLink to={"/user/" +ReactSession.get('username')} >My Profile</NavLink>
             &nbsp; &nbsp; &nbsp;
             You are logged in as: {ReactSession.get('username')}

--- a/src/components/getUsername.js
+++ b/src/components/getUsername.js
@@ -6,9 +6,10 @@ import UserProfile from '../pages/userProfile';
 function GetUsername() {
 
     const { username } = useParams();
+    const k = username;
 
     return (
-            <UserProfile username={username} />
+            <UserProfile username={username} key={k} />
       
     );
 }

--- a/src/components/notif.js
+++ b/src/components/notif.js
@@ -1,0 +1,91 @@
+import React, { Component } from "react";
+import { NavLink } from "react-router-dom";
+import Pagecss from "../pages/page.css";
+import axios from "axios";
+
+class notif extends Component {
+  constructor(props) {
+    super();
+    this.state = {
+      notif: props.notif,
+      notifProfilePic: "",
+      now: Date.now()
+    };
+  }
+
+   timeSinceNow = () => {
+
+    var seconds = Math.floor((this.state.now - Date.parse(this.state.notif.time)) / 1000);
+  
+    var interval = seconds / 31536000;
+  
+    if (interval > 1) {
+      return (Math.floor(interval) + " year" + (interval >=2 ? "s": "") +" ago");
+    }
+    interval = seconds / 2592000;
+    if (interval > 1) {
+      return (Math.floor(interval) + " month" + (interval >=2 ? "s": "") +" ago");
+    }
+    interval = seconds / 86400;
+    if (interval > 1) {
+      return (Math.floor(interval) + " day" +(interval >=2 ? "s": "") +" ago");
+    }
+    interval = seconds / 3600;
+    if (interval > 1) {
+      return (Math.floor(interval) + " hour" + (interval >=2 ? "s": "") +" ago");
+    }
+    interval = seconds / 60;
+    if (interval > 1) {
+      return (Math.floor(interval) + " minute" + (interval >=2 ? "s": "") +" ago");
+    }
+    return "just now";
+  }
+
+
+  componentDidMount() {
+    axios
+      .post("/api/profileAPI/getUserDetails", {
+        username: this.state.notif.fromUser,
+      })
+      .then((response) => {
+        this.setState({
+          notifProfilePic: response.data[0].avatarurl
+        });
+      })
+      .catch(() => {
+        console.log("An error occoured");
+      });
+  }
+
+  displayNotifText = () => {
+    if(this.state.notif.notifType === "admin") {
+        return (<>{this.state.notif.context}</>);
+    }
+    if(this.state.notif.notifType === "like") {
+        return (<><NavLink to={"/user/" +this.state.notif.fromUser}>{this.state.notif.fromUser}</NavLink>  liked your <NavLink to={"/post/" +this.state.notif.context}> post</NavLink>! </>);
+    }
+    else if(this.state.notif.notifType === "comment") {
+        return (<><NavLink to={"/user/" +this.state.notif.fromUser}>{this.state.notif.fromUser}</NavLink>  commented on your <NavLink to={"/post/" +this.state.notif.context}> post</NavLink>! </>);
+    }
+    else {
+        return (<><NavLink to={"/user/" +this.state.notif.fromUser}>{this.state.notif.fromUser}</NavLink> followed you!</>);
+    }
+
+  }
+
+  //maps each post
+  displayNotif = () => {
+    return (
+      <>
+          <NavLink to={"/user/" +this.state.notif.fromUser} ><img src={this.state.notifProfilePic} className="notifPFP"/> </NavLink>
+          {this.displayNotifText()}
+          <small style={{float: "right"}}>{this.timeSinceNow()}</small>
+      </>
+    );
+  };
+
+  render() {
+    return this.displayNotif();
+  }
+}
+export default notif;

--- a/src/components/placeholderPost/noNotifsPlaceholder.js
+++ b/src/components/placeholderPost/noNotifsPlaceholder.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './placeholderpost.css';
+ 
+const noNotifsPlaceholder = () => {
+	return (
+		<div className = "notif">
+			<p>There's nothing here... yet! When other users interact with you, you'll be notified here</p>
+		</div>
+	);
+}
+ 
+ 
+ 
+export default noNotifsPlaceholder;

--- a/src/components/placeholderPost/notifPlaceholder.js
+++ b/src/components/placeholderPost/notifPlaceholder.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import './placeholderpost.css';
+ 
+const placeholderNotif = () => {
+	return (
+		<div className = "notif">
+			<p>There are no more notifications to display...</p>
+		</div>
+	);
+}
+ 
+ 
+ 
+export default placeholderNotif;

--- a/src/pages/notifications.js
+++ b/src/pages/notifications.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import axios from 'axios';
+import Navigation from '../components/Navigation';
+import { NavLink } from 'react-router-dom';
+import { ReactSession } from 'react-client-session';
+import pagecss from './page.css'
+
+import MustLogin from '../components/mustLogin';
+import Placeholder from '../components/placeholderPost/notifPlaceholder';
+import NoNotifsPlaceholder from '../components/placeholderPost/noNotifsPlaceholder';
+import Notif from '../components/notif';
+
+class notifs extends Component {
+	
+	state = 
+	{
+		notifs:[],
+        lastNotifsCheckedTime: ""
+	}
+
+	//retrieves notifs whenever component mounts
+	componentDidMount = () => {
+		if(ReactSession.get('username') != "")
+			this.getNotifs();
+	}
+
+	//retrieves all notifs that are for the user
+	getNotifs = () => {
+		axios.post('/api/notificationAPI/getNotifs', {
+			username: ReactSession.get('username')
+		}) //api route goes here
+		.then((response) => {
+			const data = response.data;
+		  	this.setState({ notifs: data });
+		})
+		.catch(() => {
+		  	console.log('Error retrieving data!');
+		});
+
+        axios.post('/api/notificationAPI/getUpdateNotifCheckedTime', {
+			username: ReactSession.get('username')
+		}) //api route goes here
+		.then((response) => {
+			const data = response.data;
+		  	this.setState({ lastNotifsCheckedTime: data });
+		})
+		.catch(() => {
+		  	console.log('Error retrieving data!');
+		});
+	}
+	
+	//maps each notif
+	displayNotifs = (notifs) => {
+		//if there are no notifs
+		if (!notifs.length) return null;
+		return notifs.map((notif, index) => (
+			<div className={notif.time > this.state.lastNotifsCheckedTime? "newNotif": "notif"} style={{ margin: "auto" }}>
+				<Notif notif={notif}/>
+            </div>
+		));
+	}
+	
+	//rendering
+	render() {
+		return (  
+			<div>
+				<MustLogin />
+				<Navigation />
+				{this.displayNotifs(this.state.notifs)}
+				{this.state.notifs.length ==0 ? <NoNotifsPlaceholder />: null}
+			</div> 
+		);
+	}
+}
+
+export default notifs;

--- a/src/pages/page.css
+++ b/src/pages/page.css
@@ -181,3 +181,44 @@
     width: 100%;
     border-bottom: 2px ridge black;
 }
+
+.notif {
+    display: block;
+	width: 70%;
+    margin-top: 10px;
+	margin: auto;
+    margin-bottom: 20px;
+    border-top: 1px ridge #999;
+	border-bottom: 1px ridge #999;
+	padding: 10px;
+	text-align:left;
+}
+.notif:hover {
+    background-image: linear-gradient(to right, white, rgb(225, 235, 245), white);
+}
+
+.newNotif {
+    background-image: linear-gradient(to right, white, aliceblue, white);
+    display: block;
+	width: 70%;
+    margin-top: 10px;
+	margin: auto;
+    margin-bottom: 20px;
+    border-top: 1px ridge #999;
+	border-bottom: 2px ridge #999;
+	padding: 10px;
+	text-align:left;
+}
+.newNotif:hover {
+    background-image: linear-gradient(to right, white, rgb(225, 235, 245), white);
+}
+.notifPFP {
+    display: inline;
+    vertical-align: middle;
+    margin-right: 5px;
+    width: 75px;
+    height: 75px;
+    border-radius: 50%;
+    background: white;
+    overflow: hidden;
+}

--- a/src/pages/userProfile.js
+++ b/src/pages/userProfile.js
@@ -17,8 +17,7 @@ class profile extends Component {
             likes: [],
             redir: false
         }
-    
-
+        
     componentDidMount() {
 
         axios.post('/api/userAPI/checkUser',  {


### PR DESCRIPTION
Notifications are now implemented! Upon liking or commenting on a post or following another user, that user will be sent a notification. Notifications can be viewed at /notifications.
A user's 25 most recent notifications will appear newest first, and notifications that have appeared since the last time the user checked this page will be highlighted. If a user has no notifications, a placeholder will be displayed instead.
All notifications include a timestamp, the profile picture of the user that generated them, and a link to that user's profile. If a notification relates to a post, a link to that post will be present as well
fully resolves #59
Changes:
-Added a new field: notifCheckedTime to users to store when they last accessed the notification page
-Added notificationsAPI.js to handle getting notifications and updating when the user last accessed the notification page and added this new API to server.js
-Implemented generating notifications in postAPI (liking/commenting) and profile API (following)
-Implemented the notifications page and styling and added it to the navbar and routing
-Added placeholder notifications. notifPlaceholder isn't currently used, but could be in the future if pages are added to notifications
-Finally, fixed the bug where the profile page wouldn't refresh upon switching profiles via react-router. Passing an unused key prop to the profile page is enough to force it to re-mount.